### PR TITLE
Temporal Tab width full span

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -130,7 +130,7 @@ input[type=text], select {
   border: 0.5px solid #bcbdbd;
   width: auto;
   overflow: hidden;
-  min-width: 70%;
+  flex: 1;
 }
 #exportBtn{
   position: absolute;


### PR DESCRIPTION
flex in css expands items to fill available free space or shrinks them to prevent overflow. flex: 1 specifically allows it to expand to fill the widgetContainer
<img width="922" alt="Screen Shot 2020-07-17 at 4 24 44 PM" src="https://user-images.githubusercontent.com/11529801/87838272-55742980-c84b-11ea-9b48-671f9e1c98cb.png">
<img width="941" alt="Screen Shot 2020-07-17 at 4 24 32 PM" src="https://user-images.githubusercontent.com/11529801/87838280-5c02a100-c84b-11ea-9183-95742c93299d.png">

