### PR TITLE
Handle deselect bug by fixing logic in onItemSelected for chart galleries

### DIFF
--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -33,7 +33,7 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
             var selectedIndex = selectedIndexes.indexOf(index);
             if (selectedIndex > -1) {
               dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]})
-              selectedIndexes.splice(selectedIndex, 1);
+              selectedIndexes = selectedIndexes.filter(item => item != index);
               props.onChange(selectedIndexes);
             } else {
               dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]})


### PR DESCRIPTION
FRAME 1:
<img width="898" alt="Screen Shot 2020-07-27 at 11 11 32 AM" src="https://user-images.githubusercontent.com/11529801/88576313-19368b00-cffa-11ea-9748-f013276ee3cf.png">
FRAME 2:
<img width="876" alt="Screen Shot 2020-07-27 at 11 11 52 AM" src="https://user-images.githubusercontent.com/11529801/88576308-18055e00-cffa-11ea-822d-ca6905687dce.png">
FRAME 3:
<img width="886" alt="Screen Shot 2020-07-27 at 11 12 20 AM" src="https://user-images.githubusercontent.com/11529801/88576301-150a6d80-cffa-11ea-8a1d-9690100cc526.png">




[Screen Recording.zip](https://github.com/lux-org/lux-widget/files/4983736/Screen.Recording.zip)
