### PR TITLE
Collapsable warning box

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -209,7 +209,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           warnBtn = <i  id="warnBtn" 
                           className='fa fa-exclamation-triangle'
                           onClick={(e)=>this.openPanel(e)}/>;
-          warnMsg = <div className="warning-footer" style={{visibility: (this.state.openWarning) ? 'visible' : 'hidden' }} >
+          warnMsg = <div className="warning-footer" style={{display: (this.state.openWarning) ? 'flex' : 'none' }} >
           <p className="warnMsgText" dangerouslySetInnerHTML={{__html: this.state.message}}></p> 
           <i className="fa fa-window-close" aria-hidden="true" onClick={(e)=>this.closePanel(e)}
           style={{position: 'absolute', right: '15px', fontSize: '15px' }}


### PR DESCRIPTION
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11529801/93145634-b2505c80-f6a1-11ea-8f5b-1546cf1ef2de.gif)
fixed by switching from visibility to display css, in order to collapse css