### PR TITLE
Export Alert Msg 'X' Bugfix and Link Opens in New Tab

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -95,6 +95,11 @@ export class JupyterWidgetView extends DOMWidgetView {
       closePanel(e){
         this.setState({openWarning:false})
       }
+
+      closeExportInfo(){// called to close alert pop up upon export button hit by user
+        this.setState({showAlert:false});
+        console.log("FUCNTION WAS RUN");
+      }
   
       onChange(model:any){// called when the variable is changed in the view.model
         this.setState(model.changed);
@@ -199,8 +204,9 @@ export class JupyterWidgetView extends DOMWidgetView {
           alertBtn= <Alert id="alertBox" 
                            key="infoAlert" 
                            variant="info" 
+                           onClose={() => this.closeExportInfo()} 
                            dismissible>
-                      Access exported visualizations via the property `exported` (<a href="https://lux-api.readthedocs.io/en/latest/source/guide/export.html">More details</a>)
+                      Access exported visualizations via the property `exported` (<a href="https://lux-api.readthedocs.io/en/latest/source/guide/export.html" target="_blank">More details</a>)
                     </Alert>
         }
         let warnBtn;

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -98,7 +98,6 @@ export class JupyterWidgetView extends DOMWidgetView {
 
       closeExportInfo(){// called to close alert pop up upon export button hit by user
         this.setState({showAlert:false});
-        console.log("FUCNTION WAS RUN");
       }
   
       onChange(model:any){// called when the variable is changed in the view.model


### PR DESCRIPTION
Fixed bug in alert message where 'x' would not close alert message. Added functionality so that the link in the alert message redirects to API in a new tab/window based on user's browser preferences rather in the current tab.