### PR TITLE
Making export button dimmer and not selectable when no cards are selected

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -191,11 +191,20 @@ export class JupyterWidgetView extends DOMWidgetView {
 
       render(){
         let exportBtn;
+        var exportEnabled = Object.keys(this.state._exportedVisIdxs).length > 0
         if (this.state.tabItems.length>0){
-          exportBtn = <i  id="exportBtn" 
-                          className='fa fa-upload' 
-                          title='Export selected visualization into variable'
-                          onClick={(e) => this.exportSelection()}/>
+          if (exportEnabled) {
+            exportBtn = <i  id="exportBtn" 
+                            className='fa fa-upload' 
+                            title='Export selected visualization into variable'
+                            onClick={(e) => this.exportSelection()}/>
+                            
+          } else {
+            exportBtn = <i  id="exportBtn" 
+                            className= 'fa fa-upload'
+                            style={{opacity: 0.2, cursor: 'not-allowed'}}
+                            title='Select card(s) to export into variable'/>
+          }
         }
 
         let alertBtn;


### PR DESCRIPTION
This PR addresses Issue #43 

When there are no cards selected, the upload button is grayed out and made un-unclickable with a message that explains to select cards to export.

![upload](https://user-images.githubusercontent.com/46768380/93727002-f6de6b00-fb6d-11ea-8810-f4f4c78eefa1.gif)

