### PR TITLE
Added ability to delete selectable cards

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -145,7 +145,7 @@ input[type=text], select {
 #alertBox{
   position: absolute;
   left: 23%;
-  width: 52%;
+  width: 54%;
   bottom: 6%;
   padding: 5px 30px 5px 10px;
 }

--- a/css/widget.css
+++ b/css/widget.css
@@ -133,6 +133,15 @@ input[type=text], select {
   font-size: 20px;
   padding: 5px;
 }
+
+#deleteBtn{
+  position: absolute;
+  top: 42px;
+  right: 33px;
+  font-size: 20px;
+  padding: 5px;
+}
+
 #alertBox{
   position: absolute;
   left: 23%;

--- a/luxWidget/widget.py
+++ b/luxWidget/widget.py
@@ -17,6 +17,7 @@ class LuxWidget(DOMWidget):
     recommendations = List([]).tag(sync=True)
     data = List([]).tag(sync=True)
     _exportedVisIdxs = Dict({}).tag(sync=True)
+    deletedIndices = Dict({}).tag(sync=True)
     intent = Unicode("").tag(sync=True)
     message = Unicode("").tag(sync=True)
     def __init__(self, currentVis=None, recommendations=None, intent=None, message=None,**kwargs):

--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -14,7 +14,6 @@ interface chartGalleryProps{
     graphSpec: object[],
     description: string,
     currentVisShow: boolean,
-    prevPlotCnt?: number
 }
 
 class ChartGalleryComponent extends Component<chartGalleryProps,any> {
@@ -23,13 +22,8 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
         var selected = props.multiple ? [] : -1;
         var initialState = {
           selected: selected,
-          prevPlotCnt: this.props.graphSpec.length
         };
         this.state = initialState;
-    }
-
-    componentDidUpdate(){
-      this.checkDeleteStatus();
     }
 
     onItemSelected(index) {
@@ -62,11 +56,11 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
         });
       }
 
-    checkDeleteStatus() {
-      if (this.state.prevPlotCnt != this.props.graphSpec.length) {
-        this.setState({prevPlotCnt: this.props.graphSpec.length, selected:[]});
-      }
+    removeDeletedCharts() {
+      this.setState({selected:[]});
+      //this.props.onChange(this.state.selected);
     }
+    
     render() {
         console.log('chart render');
         return (

--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -14,6 +14,7 @@ interface chartGalleryProps{
     graphSpec: object[],
     description: string,
     currentVisShow: boolean,
+    prevPlotCnt?: number
 }
 
 class ChartGalleryComponent extends Component<chartGalleryProps,any> {
@@ -22,9 +23,15 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
         var selected = props.multiple ? [] : -1;
         var initialState = {
           selected: selected,
+          prevPlotCnt: this.props.graphSpec.length
         };
         this.state = initialState;
     }
+
+    componentDidUpdate(){
+      this.checkDeleteStatus();
+    }
+
     onItemSelected(index) {
         // Implementation based on https://codepen.io/j-burgos/pen/VpQxLv
         this.setState((prevState, props) => {
@@ -54,8 +61,14 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
           }
         });
       }
+
+    checkDeleteStatus() {
+      if (this.state.prevPlotCnt != this.props.graphSpec.length) {
+        this.setState({prevPlotCnt: this.props.graphSpec.length, selected:[]});
+      }
+    }
     render() {
-      console.log('chart render');
+        console.log('chart render');
         return (
           <div className="chartGalleryTabContent">
             <p className="text-description" dangerouslySetInnerHTML={{__html: this.props.description}}/>

--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -58,7 +58,6 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
 
     removeDeletedCharts() {
       this.setState({selected:[]});
-      //this.props.onChange(this.state.selected);
     }
     
     render() {

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -77,7 +77,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           activeTab: props.activeTab,
           showAlert:false,
           selectedRec:{},
-          _exportedVisIdxs:[],
+          _exportedVisIdxs:{},
           currentVisSelected: -2,
           openWarning:false
         }
@@ -172,6 +172,23 @@ export class JupyterWidgetView extends DOMWidgetView {
 
       deleteSelection() {
 
+        console.log(this.state.recommendations);
+        console.log(this.state._exportedVisIdxs);
+
+        for (var recommendation of this.props.model.get("recommendations")) {
+          if (this.state._exportedVisIdxs[recommendation.action]) {
+            for (var index of this.state._exportedVisIdxs[recommendation.action]) {
+              recommendation.vspec.splice(index,1);
+            }
+          }
+        }
+
+        // dispatchLogEvent("deleteBtnClick",this.state._exportedVisIdxs);
+        this.setState({
+            selectedRec:[],
+            _exportedVisIdxs:{},
+            recommendations: this.props.model.get("recommendations")
+        });
       }
 
       generateTabItems() {
@@ -201,7 +218,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           if (exportEnabled) {
             exportBtn = <i  id="exportBtn" 
                             className='fa fa-upload' 
-                            title='Export selected visualization into variable TEST'
+                            title='Export selected visualization into variable'
                             onClick={(e) => this.exportSelection()}/>
                             
           } else {
@@ -217,14 +234,14 @@ export class JupyterWidgetView extends DOMWidgetView {
         if (this.state.tabItems.length > 0){
           if (deleteEnabled) {
             deleteBtn = <i id="deleteBtn"
-                           className="fas fa-trash"
-                           title='Deleted Cards'
-                           onClick={(e) => this.deleteSelection()}></i>
+                           className="fa fa-trash"
+                           title='Delete Selected Cards'
+                           onClick={(e) => this.deleteSelection()}/>
           } else {
             deleteBtn = <i id="deleteBtn"
-                           className="fas fa-trash"
+                           className="fa fa-trash"
                            style={{opacity: 0.2, cursor: 'not-allowed'}}
-                           title='Select card(s) to delete'></i>
+                           title='Select card(s) to delete'/>
           }
         }
 
@@ -258,7 +275,6 @@ export class JupyterWidgetView extends DOMWidgetView {
                   <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <CurrentVisComponent intent={this.state.intent} currentVisSpec={this.state.currentVis} numRecommendations={0}
                     onChange={this.handleCurrentVisSelect}/>
-                    {exportBtn}
                     {deleteBtn}
                     {exportBtn}
                     {alertBtn}
@@ -277,7 +293,6 @@ export class JupyterWidgetView extends DOMWidgetView {
                           {this.state.tabItems}
                         </Tabs>
                       </div>
-                      {exportBtn}
                       {deleteBtn}
                       {exportBtn}
                       {alertBtn}

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -85,6 +85,7 @@ export class JupyterWidgetView extends DOMWidgetView {
         this.handleCurrentVisSelect = this.handleCurrentVisSelect.bind(this);
         this.handleSelect = this.handleSelect.bind(this);
         this.exportSelection = this.exportSelection.bind(this);
+        this.deleteSelection = this.deleteSelection.bind(this);
         this.openPanel = this.openPanel.bind(this);
         this.closePanel = this.closePanel.bind(this);
       }
@@ -169,6 +170,10 @@ export class JupyterWidgetView extends DOMWidgetView {
         view.model.set('_exportedVisIdxs',this.state._exportedVisIdxs);
       }
 
+      deleteSelection() {
+
+      }
+
       generateTabItems() {
         return (
           this.props.model.get("recommendations").map((actionResult,tabIdx) =>
@@ -196,7 +201,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           if (exportEnabled) {
             exportBtn = <i  id="exportBtn" 
                             className='fa fa-upload' 
-                            title='Export selected visualization into variable'
+                            title='Export selected visualization into variable TEST'
                             onClick={(e) => this.exportSelection()}/>
                             
           } else {
@@ -204,6 +209,22 @@ export class JupyterWidgetView extends DOMWidgetView {
                             className= 'fa fa-upload'
                             style={{opacity: 0.2, cursor: 'not-allowed'}}
                             title='Select card(s) to export into variable'/>
+          }
+        }
+
+        let deleteBtn;
+        var deleteEnabled = Object.keys(this.state._exportedVisIdxs).length > 0
+        if (this.state.tabItems.length > 0){
+          if (deleteEnabled) {
+            deleteBtn = <i id="deleteBtn"
+                           className="fas fa-trash"
+                           title='Deleted Cards'
+                           onClick={(e) => this.deleteSelection()}></i>
+          } else {
+            deleteBtn = <i id="deleteBtn"
+                           className="fas fa-trash"
+                           style={{opacity: 0.2, cursor: 'not-allowed'}}
+                           title='Select card(s) to delete'></i>
           }
         }
 
@@ -238,6 +259,8 @@ export class JupyterWidgetView extends DOMWidgetView {
                     <CurrentVisComponent intent={this.state.intent} currentVisSpec={this.state.currentVis} numRecommendations={0}
                     onChange={this.handleCurrentVisSelect}/>
                     {exportBtn}
+                    {deleteBtn}
+                    {exportBtn}
                     {alertBtn}
                   </div>               
                 </div>);
@@ -254,6 +277,8 @@ export class JupyterWidgetView extends DOMWidgetView {
                           {this.state.tabItems}
                         </Tabs>
                       </div>
+                      {exportBtn}
+                      {deleteBtn}
                       {exportBtn}
                       {alertBtn}
                     </div>

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -178,6 +178,10 @@ export class JupyterWidgetView extends DOMWidgetView {
         view.model.set('_exportedVisIdxs',this.state._exportedVisIdxs);
       }
 
+      /* 
+       * Goes through all selections and removes and clears any selections across recommendation tabs.
+       * Re-renders each chart component, with the updated recommedations.
+       */
       deleteSelection() {
         for (var recommendation of this.props.model.get("recommendations")) {
           if (this.state._exportedVisIdxs[recommendation.action]) {
@@ -195,7 +199,6 @@ export class JupyterWidgetView extends DOMWidgetView {
             recommendations: this.props.model.get("recommendations")
         });
 
-        //Deletes all selected charts across tabs
         for (var i = 0; i < this.props.model.get("recommendations").length; i++) {
           this.chartComponents[i].current.removeDeletedCharts();
         }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -66,8 +66,15 @@ export class JupyterWidgetView extends DOMWidgetView {
     }
 
     class ReactWidget extends React.Component<JupyterWidgetView,WidgetProps> {
+      private chartComponents = Array<any>();
+
       constructor(props:any){
         super(props);
+
+        for (var i = 0; i < this.props.model.get("recommendations").length; i++) {
+          this.chartComponents.push(React.createRef<ChartGalleryComponent>());
+        }
+
         this.state = {
           currentVis :  props.model.get("current_vis"),
           recommendations:  props.model.get("recommendations"),
@@ -81,7 +88,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           currentVisSelected: -2,
           openWarning:false
         }
-        
+
         // This binding is necessary to make `this` work in the callback
         this.handleCurrentVisSelect = this.handleCurrentVisSelect.bind(this);
         this.handleSelect = this.handleSelect.bind(this);
@@ -188,6 +195,10 @@ export class JupyterWidgetView extends DOMWidgetView {
             recommendations: this.props.model.get("recommendations")
         });
 
+        //Deletes all selected charts across tabs
+        for (var i = 0; i < this.props.model.get("recommendations").length; i++) {
+          this.chartComponents[i].current.removeDeletedCharts();
+        }
       }
 
       generateTabItems() {
@@ -198,6 +209,7 @@ export class JupyterWidgetView extends DOMWidgetView {
                   // this exists to prevent chart gallergy from refreshing while changing tabs
                   // This is an anti-pattern for React, but is necessary here because our chartgallery is very expensive to initialize
                   key={'no refresh'}
+                  ref={this.chartComponents[tabIdx]}
                   title={actionResult.action}
                   description={actionResult.description}
                   multiple={true}

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -175,6 +175,8 @@ export class JupyterWidgetView extends DOMWidgetView {
            }));
         },60000);
         view.model.set('_exportedVisIdxs', this.state._exportedVisIdxs);
+        view.model.save();
+
       }
 
       /* 
@@ -186,6 +188,7 @@ export class JupyterWidgetView extends DOMWidgetView {
         var toDelete = {};
         var deletionQueue = view.model.get('deletedIndices');
 
+        // Logic for keeping track of multiple deletions between exports
         if (deletionQueue !== {}) {
           for (var recommendation of this.state.recommendations) {
             if (this.state._exportedVisIdxs[recommendation.action]) {
@@ -211,6 +214,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           toDelete = this.state._exportedVisIdxs;
         }
 
+        // Deleting from the frontend's visualization data structure
         for (var recommendation of this.state.recommendations) {
           if (this.state._exportedVisIdxs[recommendation.action]) {
             let delCount = 0;
@@ -227,7 +231,9 @@ export class JupyterWidgetView extends DOMWidgetView {
         });
 
         view.model.set('deletedIndices', toDelete);
+        view.model.save();
 
+        // Re-render each tab's components to update deletions
         for (var i = 0; i < this.props.model.get("recommendations").length; i++) {
           this.chartComponents[i].current.removeDeletedCharts();
         }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -62,7 +62,7 @@ export class JupyterWidgetView extends DOMWidgetView {
       selectedRec:object,
       _exportedVisIdxs:object,
       currentVisSelected:number,
-      openWarning: boolean,
+      openWarning: boolean
     }
 
     class ReactWidget extends React.Component<JupyterWidgetView,WidgetProps> {
@@ -81,6 +81,7 @@ export class JupyterWidgetView extends DOMWidgetView {
           currentVisSelected: -2,
           openWarning:false
         }
+        
         // This binding is necessary to make `this` work in the callback
         this.handleCurrentVisSelect = this.handleCurrentVisSelect.bind(this);
         this.handleSelect = this.handleSelect.bind(this);
@@ -171,24 +172,22 @@ export class JupyterWidgetView extends DOMWidgetView {
       }
 
       deleteSelection() {
-
-        console.log(this.state.recommendations);
-        console.log(this.state._exportedVisIdxs);
-
         for (var recommendation of this.props.model.get("recommendations")) {
           if (this.state._exportedVisIdxs[recommendation.action]) {
+            let delCount = 0;
             for (var index of this.state._exportedVisIdxs[recommendation.action]) {
-              recommendation.vspec.splice(index,1);
+              recommendation.vspec.splice(index - delCount,1);
+              delCount++;
             }
           }
         }
 
-        // dispatchLogEvent("deleteBtnClick",this.state._exportedVisIdxs);
         this.setState({
-            selectedRec:[],
-            _exportedVisIdxs:{},
+            selectedRec: [],
+            _exportedVisIdxs: {},
             recommendations: this.props.model.get("recommendations")
         });
+
       }
 
       generateTabItems() {
@@ -205,7 +204,8 @@ export class JupyterWidgetView extends DOMWidgetView {
                   maxSelectable={10}
                   onChange={this.onListChanged.bind(this,tabIdx)}
                   graphSpec={actionResult.vspec}
-                  currentVisShow={!_.isEmpty(this.props.model.get("current_vis"))}/> 
+                  currentVisShow={!_.isEmpty(this.props.model.get("current_vis"))}
+                  /> 
             </Tab>
           )
         )
@@ -236,7 +236,7 @@ export class JupyterWidgetView extends DOMWidgetView {
             deleteBtn = <i id="deleteBtn"
                            className="fa fa-trash"
                            title='Delete Selected Cards'
-                           onClick={(e) => this.deleteSelection()}/>
+                           onClick={() => this.deleteSelection()}/>
           } else {
             deleteBtn = <i id="deleteBtn"
                            className="fa fa-trash"


### PR DESCRIPTION
Linked Issue: https://github.com/lux-org/lux-widget/issues/42

Added icon to allow cards to be deleted. Cannot recover cards unless the jupyter cell is re-run. Can delete across multiple tabs.

![predelete](https://user-images.githubusercontent.com/47467363/94350575-3ee50e00-0004-11eb-86af-5fbaacf27b5d.PNG)
![postdelete](https://user-images.githubusercontent.com/47467363/94350578-43112b80-0004-11eb-9862-7962ad110b12.PNG)
