### PR TITLE
Widget changes to logging - popup interaction and data recorded

### DIFF
--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -44,11 +44,19 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
             var selectedIndexes = prevState.selected;
             var selectedIndex = selectedIndexes.indexOf(index);
             if (selectedIndex > -1) {
-              dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]})
+              // dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]});
+              dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,
+                                              "title":this.props.graphSpec[index]['config']['title'],
+                                              "mark":this.props.graphSpec[index]['mark'],
+                                              "encoding":this.props.graphSpec[index]['encoding']})
               selectedIndexes = selectedIndexes.filter(item => item != index);
               props.onChange(selectedIndexes);
             } else {
-              dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]})
+              // dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]});
+              dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,
+                                            "title":this.props.graphSpec[index]['config']['title'],
+                                            "mark":this.props.graphSpec[index]['mark'],
+                                            "encoding":this.props.graphSpec[index]['encoding']})
               if (!(selectedIndexes.length >= props.maxSelectable)) {
                 selectedIndexes.push(index);
                 props.onChange(selectedIndexes);

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -115,11 +115,11 @@ export class LuxWidgetView extends DOMWidgetView {
       }
 
       openPanel(e){
-        dispatchLogEvent("openPanel",this.state.message);
+        dispatchLogEvent("openWarning",this.state.message);
         this.setState({openWarning:true});
       }
       closePanel(e){
-        dispatchLogEvent("closePanel",this.state.message);
+        dispatchLogEvent("closeWarning",this.state.message);
         this.setState({openWarning:false});
       }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -115,14 +115,17 @@ export class LuxWidgetView extends DOMWidgetView {
       }
 
       openPanel(e){
-        this.setState({openWarning:true})
+        dispatchLogEvent("openPanel",this.state.message);
+        this.setState({openWarning:true});
       }
       closePanel(e){
-        this.setState({openWarning:false})
+        dispatchLogEvent("closePanel",this.state.message);
+        this.setState({openWarning:false});
       }
 
       // called to close alert pop up upon export button hit by user
       closeExportInfo() {
+        dispatchLogEvent("closeExportInfo", null);
         this.setState({
           showAlert: false});
       }


### PR DESCRIPTION
- Added logging for opening and closing warning panel 
- Added logging for closing export pop up 
- Reduced data logged when clicking and unblocking viz to just title, encoding, and mark


Testing
- install widget + logger
- open/close warning panel in lux widget, verify action is logged
- hit export button and close pop up, verify action is logged
- click/unclick viz, verify title/encoding/mark is only logged


