### PR TITLE
Fixing notebook/lab installation bug

### DIFF
--- a/luxwidget/_version.py
+++ b/luxwidget/_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-version_info = (0, 1, 2)
+version_info = (0, 1, 3)
 __version__ = ".".join(map(str, version_info))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxwidget",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Custom Jupyter Widget Library",
   "keywords": [
     "jupyter",
@@ -74,8 +74,8 @@
     "@lumino/application": "^1.6.0",
     "@lumino/widgets": "^1.8.0",
     "@types/expect.js": "^0.3.29",
-    "@types/mocha": "^5.2.5",
     "@types/jquery": "^3.5.4",
+    "@types/mocha": "^5.2.5",
     "@types/node": "^10.11.6",
     "@types/react": "^16.9.16",
     "@types/react-dom": "^16.9.4",
@@ -90,7 +90,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.4",
+    "typescript": "^3.8",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
 name = 'luxwidget'
 
 # Ensure a valid python version
-ensure_python('>=3.4')
+ensure_python('>=3.7')
 
 # Get our version
 version = get_version(pjoin(name, '_version.py'))
@@ -55,13 +55,11 @@ package_data_spec = {
     ]
 }
 
-data_files_spec = [
-    ('share/jupyter/nbextensions/luxwidget',
-        nb_path, '*.js*'),
-    ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
-    ('etc/jupyter/nbconfig/notebook.d' , HERE, 'luxwidget.json')
-]
-
+# data_files_spec = [
+#     ('share/jupyter/nbextensions/luxwidget', nb_path, '*.js*'),
+#     ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
+#     ('etc/jupyter/nbconfig/notebook.d' , HERE, 'luxwidget.json')
+# ]
 
 # cmdclass = create_cmdclass('jsdeps', package_data_spec=package_data_spec,
 #     data_files_spec=data_files_spec)
@@ -71,7 +69,7 @@ data_files_spec = [
 # )
 
 
-setup(
+setup_args = dict(
     name            = 'lux-widget',
     description     = 'Jupyter Widget for Intelligent Data Discovery',
     long_description= long_description, 
@@ -98,6 +96,15 @@ setup(
         'Framework :: Jupyter'
     ],
     include_package_data = True,
+    data_files=[
+        ('share/jupyter/nbextensions/luxwidget', [
+                'luxwidget/nbextension/static/extension.js',
+                'luxwidget/nbextension/static/index.js',
+                'luxwidget/nbextension/static/index.js.map',
+        ]),
+    ],
     setup_requires=install_requires,
     install_requires=install_requires
 )
+
+setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -55,20 +55,6 @@ package_data_spec = {
     ]
 }
 
-# data_files_spec = [
-#     ('share/jupyter/nbextensions/luxwidget', nb_path, '*.js*'),
-#     ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
-#     ('etc/jupyter/nbconfig/notebook.d' , HERE, 'luxwidget.json')
-# ]
-
-# cmdclass = create_cmdclass('jsdeps', package_data_spec=package_data_spec,
-#     data_files_spec=data_files_spec)
-# cmdclass['jsdeps'] = combine_commands(
-#     install_npm(HERE, build_cmd='build:all'),
-#     ensure_targets(jstargets),
-# )
-
-
 setup_args = dict(
     name            = 'lux-widget',
     description     = 'Jupyter Widget for Intelligent Data Discovery',
@@ -76,7 +62,6 @@ setup_args = dict(
     long_description_content_type='text/markdown', 
     version         = version,
     scripts         = glob(pjoin('scripts', '*')),
-    # cmdclass        = cmdclass,
     packages        = find_packages(),
     author          = 'Doris Jung-Lin Lee',
     author_email    = 'dorisjunglinlee@gmail.com',


### PR DESCRIPTION
Previously, after running `jupyter labextension install luxwidget` for JupyterLab if we also want to enable Jupyter notebook via `jupyter nbextension install` and `enable`, it errors on `static/` directory not found.
This PR fixes this issue by including the static/ directory when installing the npm package. These commands now work.
```bash
jupyter labextension install @jupyter-widgets/jupyterlab-manager
jupyter labextension install luxwidget

jupyter nbextension install --py --user luxwidget
jupyter nbextension enable --py --user luxwidget
```