### PR TITLE
Lazy Streaming of Tabs

### DIFF
--- a/luxwidget/widget.py
+++ b/luxwidget/widget.py
@@ -22,6 +22,7 @@ class LuxWidget(DOMWidget):
     intent = Unicode("").tag(sync=True)
     selectedIntentIndex = Dict({}).tag(sync=True)
     message = Unicode("").tag(sync=True)
+    loadNewTab = Unicode("").tag(sync=True)
 
     def __init__(self, currentVis=None, recommendations=None, intent=None, message=None, **kwargs):
         super().__init__(**kwargs)

--- a/src/buttonsBroker.tsx
+++ b/src/buttonsBroker.tsx
@@ -15,7 +15,7 @@ class ButtonsBroker extends Component<ButtonProps> {
       let intentBtn;
       let alertBox;
 
-      if (tabItems.length > 0){
+      if (tabItems > 0){
         if (buttonsEnabled) {
           deleteBtn = <i id="deleteBtn"
                          className="fa fa-trash"

--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -49,15 +49,19 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
           if (props.multiple) {
             var selectedIndexes = prevState.selected;
             var selectedIndex = selectedIndexes.indexOf(index);
-            dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,
-                            "title":this.props.graphSpec[index]['title'],
-                            "mark":this.props.graphSpec[index]['mark'],
-                            "encoding":this.props.graphSpec[index]['encoding']})
             if (selectedIndex > -1) {
+              dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,	
+                                              "title":this.props.graphSpec[index]['title'],	
+                                              "mark":this.props.graphSpec[index]['mark'],	
+                                              "encoding":this.props.graphSpec[index]['encoding']})
               selectedIndexes = selectedIndexes.filter(item => item != index);
               props.onChange(selectedIndexes);
             } else {
               if (!(selectedIndexes.length >= props.maxSelectable)) {
+                dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,	
+                                  "title":this.props.graphSpec[index]['title'],	
+                                  "mark":this.props.graphSpec[index]['mark'],	
+                                  "encoding":this.props.graphSpec[index]['encoding']})
                 selectedIndexes.push(index);
                 props.onChange(selectedIndexes);
               }

--- a/src/chartGallery.tsx
+++ b/src/chartGallery.tsx
@@ -49,20 +49,14 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
           if (props.multiple) {
             var selectedIndexes = prevState.selected;
             var selectedIndex = selectedIndexes.indexOf(index);
+            dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,
+                            "title":this.props.graphSpec[index]['title'],
+                            "mark":this.props.graphSpec[index]['mark'],
+                            "encoding":this.props.graphSpec[index]['encoding']})
             if (selectedIndex > -1) {
-              // dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]});
-              dispatchLogEvent("unclickVis",{"tabTitle":this.props.title,"index":index,
-                                              "title":this.props.graphSpec[index]['title'],
-                                              "mark":this.props.graphSpec[index]['mark'],
-                                              "encoding":this.props.graphSpec[index]['encoding']})
               selectedIndexes = selectedIndexes.filter(item => item != index);
               props.onChange(selectedIndexes);
             } else {
-              // dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,"vis":this.props.graphSpec[index]});
-              dispatchLogEvent("clickVis",{"tabTitle":this.props.title,"index":index,
-                                            "title":this.props.graphSpec[index]['title'],
-                                            "mark":this.props.graphSpec[index]['mark'],
-                                            "encoding":this.props.graphSpec[index]['encoding']})
               if (!(selectedIndexes.length >= props.maxSelectable)) {
                 selectedIndexes.push(index);
                 props.onChange(selectedIndexes);
@@ -103,10 +97,9 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
               <div key={idx.toString()} 
                   className="graph-container"
                   id={"graph-container-".concat(idx.toString())}>
-                  {this.state.selected.indexOf(idx) > -1 ? 
                     <SelectableCard 
                       key={idx} 
-                      selected={true} 
+                      selected={this.state.selected.indexOf(idx) > -1} 
                       onClick={(e) => {this.onItemSelected(idx);}}>
                       {'vislib' in item && 'config' in item && JSON.stringify(item['vislib']).substring(1, JSON.stringify(item['vislib']).length - 1) === 'matplotlib' ?
                       <img id="gal-img" src={"data:image/png;base64," + JSON.stringify(item['config']).substring(1, JSON.stringify(item['config']).length - 1) + "\ "}></img> :
@@ -116,20 +109,6 @@ class ChartGalleryComponent extends Component<chartGalleryProps,any> {
                         actions={false}/>
                       }
                     </SelectableCard>
-                  :
-                    <SelectableCard 
-                        key={idx}
-                        selected={false} 
-                        onClick={(e) => {this.onItemSelected(idx);}}>
-                        {'vislib' in item && 'config' in item && JSON.stringify(item['vislib']).substring(1,JSON.stringify(item['vislib']).length - 1) === 'matplotlib' ?
-                      <img id="gal-img" src={"data:image/png;base64," + JSON.stringify(item['config']).substring(1,JSON.stringify(item['config']).length - 1) + "\ "}></img> :
-                      <VegaLite
-                          spec={item}  
-                          padding={{left: 10, top: 5, right: 5, bottom: 5}}
-                          actions={false}/>
-                        }
-                    </SelectableCard>
-                  }
               </div>  
             )} title={this.props.title} currentVisShow={this.props.currentVisShow}>
             </ScrollableContent>

--- a/src/interfaces/buttonProps.ts
+++ b/src/interfaces/buttonProps.ts
@@ -1,6 +1,6 @@
 export interface ButtonProps {
     buttonsEnabled: boolean,
-    tabItems: object[],
+    tabItems: Number,
     deleteSelection: () => void,
     exportSelection: () => void,
     setIntent: () => void,

--- a/src/scrollableContent.tsx
+++ b/src/scrollableContent.tsx
@@ -79,7 +79,6 @@ class ScrollableContent extends Component<{galleryItems: JSX.Element[],title:str
         </div>
         <div id="scroll-indicator-background" style={{visibility: this.state.scrollIndicator && shouldShowScrollIndicator ? 'visible' : 'hidden' }}>
           <p id="scroll-indicator" style={{visibility: this.state.scrollIndicator && shouldShowScrollIndicator ? 'visible' : 'hidden' }}>{scrollDescription}<i id='first-arrow' className='fa fa-chevron-right'></i><i id='second-arrow' className='fa fa-chevron-right'></i> </p>
-          {/* onClick={(event)=>$('#staticOuterDiv').scrollLeft(500)} */}
         </div>
     </div>)
   }

--- a/src/scrollableContent.tsx
+++ b/src/scrollableContent.tsx
@@ -67,18 +67,21 @@ class ScrollableContent extends Component<{galleryItems: JSX.Element[],title:str
       shouldShowScrollIndicator = true;
       numMoreCharts -= 3;
     }
-    var scrollDescription:string;
+    var scrollDescription: string;
     if(numMoreCharts==1){
-      scrollDescription= "Scroll for "+numMoreCharts+" more chart"
+      scrollDescription= "Scroll for " + numMoreCharts + " more chart";
     }else{
-      scrollDescription= "Scroll for "+numMoreCharts+" more charts"
+      scrollDescription= "Scroll for " + numMoreCharts + " more charts";
     }
     return (<div id="staticOuterDiv" className="recommendationStaticContentOuter" onScroll={this.handleScroll}>
         <div id="mult-graph-container" className= "recommendationContentInner">
             {this.props.galleryItems}
         </div>
         <div id="scroll-indicator-background" style={{visibility: this.state.scrollIndicator && shouldShowScrollIndicator ? 'visible' : 'hidden' }}>
-          <p id="scroll-indicator" style={{visibility: this.state.scrollIndicator && shouldShowScrollIndicator ? 'visible' : 'hidden' }}>{scrollDescription}<i id='first-arrow' className='fa fa-chevron-right'></i><i id='second-arrow' className='fa fa-chevron-right'></i> </p>
+          <p id="scroll-indicator" style={{visibility: this.state.scrollIndicator && shouldShowScrollIndicator ? 'visible' : 'hidden' }}>
+            {scrollDescription}
+            <i id='first-arrow' className='fa fa-chevron-right'></i><i id='second-arrow' className='fa fa-chevron-right'></i> 
+          </p>
         </div>
     </div>)
   }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -67,7 +67,7 @@ export class LuxWidgetView extends DOMWidgetView {
       intent:string,
       selectedIntentIndex: object,
       message:string,
-      tabItems:any,
+      tabItems:Tab[],
       activeTab:any,
       showAlert:boolean,
       selectedRec:object,
@@ -111,6 +111,7 @@ export class LuxWidgetView extends DOMWidgetView {
         this.deleteSelection = this.deleteSelection.bind(this);
         this.setIntent = this.setIntent.bind(this);
         this.closeExportInfo = this.closeExportInfo.bind(this);
+        this.updateTabs = this.updateTabs.bind(this);
       }
 
       toggleWarningPanel(e){
@@ -259,33 +260,69 @@ export class LuxWidgetView extends DOMWidgetView {
       }
 
       generateTabItems() {
-        return (
-          this.props.model.get("recommendations").map((actionResult,tabIdx) =>
-            <Tab eventKey={actionResult.action} title={actionResult.action} >
+        var tabs = [];
+        for (let i = 0; i < this.props.model.get("recommendations").length; i++) {
+          var actionResult = this.props.model.get("recommendations")[i];
+          var disabled = actionResult.vspec.length == 0;
+          tabs.push(
+            <Tab eventKey={actionResult.action} title={actionResult.action} disabled={disabled}>
               <ChartGalleryComponent 
                   // this exists to prevent chart gallery from refreshing while changing tabs
                   // This is an anti-pattern for React, but is necessary here because our chartgallery is very expensive to initialize
                   key={'no refresh'}
-                  ref={this.chartComponents[tabIdx]}
+                  ref={this.chartComponents[i]}
                   title={actionResult.action}
                   description={actionResult.description}
                   longDescription={actionResult.long_description}
                   multiple={true}
                   maxSelectable={10}
-                  onChange={this.onListChanged.bind(this,tabIdx)}
+                  onChange={this.onListChanged.bind(this,i)}
                   graphSpec={actionResult.vspec}
                   currentVisShow={!_.isEmpty(this.props.model.get("current_vis"))}
                   openInfo={false}
                   /> 
-            </Tab>
-          )
-        )
+            </Tab>);
+          }
+        return tabs;
+      }
+
+      updateTabs() {
+        var tabs = [];
+        for (var i = 0; i < this.state.tabItems.length; i++) {
+            if (this.state.tabItems[i].props.title === this.props.model.get("loadNewTab")) {
+              var actionResult = this.props.model.get("recommendations")[i];
+              tabs.push(
+                <Tab eventKey={actionResult.action} title={actionResult.action} disabled={false}>
+                  <ChartGalleryComponent 
+                      // this exists to prevent chart gallery from refreshing while changing tabs
+                      // This is an anti-pattern for React, but is necessary here because our chartgallery is very expensive to initialize
+                      key={'no refresh'}
+                      ref={this.chartComponents[i]}
+                      title={actionResult.action}
+                      description={actionResult.description}
+                      longDescription={actionResult.long_description}
+                      multiple={true}
+                      maxSelectable={10}
+                      onChange={this.onListChanged.bind(this,i)}
+                      graphSpec={actionResult.vspec}
+                      currentVisShow={!_.isEmpty(this.props.model.get("current_vis"))}
+                      openInfo={false}
+                      /> 
+                </Tab>);
+            } else {
+              tabs.push(this.state.tabItems[i]);
+            }
+        }
+        this.setState({
+          tabItems: tabs
+        })
+        console.log("tab update func called");
       }
 
       render() {
+        view.listenTo(view.model, 'change:loadNewTab', this.updateTabs);
         var buttonsEnabled = Object.keys(this.state._selectedVisIdxs).length > 0;
         var intentEnabled = Object.keys(this.state._selectedVisIdxs).length == 1 && Object.values(this.state._selectedVisIdxs)[0].length == 1;
-        
         if (this.state.recommendations.length == 0) {
           return (<div id="oneViewWidgetContainer" style={{ flexDirection: 'column' }}>
                   {/* {attributeShelf}
@@ -299,7 +336,7 @@ export class LuxWidgetView extends DOMWidgetView {
                                      exportSelection={this.exportSelection}
                                      setIntent={this.setIntent}
                                      closeExportInfo={this.closeExportInfo}
-                                     tabItems={this.state.tabItems}
+                                     tabItems={this.state.tabItems.length}
                                      showAlert={this.state.showAlert}
                                      intentEnabled={intentEnabled}
                                      />               
@@ -323,7 +360,7 @@ export class LuxWidgetView extends DOMWidgetView {
                                      exportSelection={this.exportSelection}
                                      setIntent={this.setIntent}
                                      closeExportInfo={this.closeExportInfo}
-                                     tabItems={this.state.tabItems}
+                                     tabItems={this.state.tabItems.length}
                                      showAlert={this.state.showAlert}
                                      intentEnabled={intentEnabled}
                                      />

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -327,33 +327,19 @@ export class LuxWidgetView extends DOMWidgetView {
         view.listenTo(view.model, 'change:loadNewTab', this.updateTabs);
         var buttonsEnabled = Object.keys(this.state._selectedVisIdxs).length > 0;
         var intentEnabled = Object.keys(this.state._selectedVisIdxs).length == 1 && Object.values(this.state._selectedVisIdxs)[0].length == 1;
-        if (this.state.recommendations.length == 0) {
-          return (<div id="oneViewWidgetContainer" style={{ flexDirection: 'column' }}>
-                  <div style={{ display: 'flex', flexDirection: 'row' }}>
-                    <CurrentVisComponent intent={this.state.intent} currentVisSpec={this.state.currentVis} numRecommendations={0}
-                    onChange={this.handleCurrentVisSelect}/>
-                  </div>
-                  <ButtonsBroker buttonsEnabled={buttonsEnabled}
-                                     deleteSelection={this.deleteSelection}
-                                     exportSelection={this.exportSelection}
-                                     setIntent={this.setIntent}
-                                     closeExportInfo={this.closeExportInfo}
-                                     tabItems={this.state.tabItems.length}
-                                     showAlert={this.state.showAlert}
-                                     intentEnabled={intentEnabled}
-                                     />               
-                </div>);
-        } else {
-          return (<div id="widgetContainer" style={{ flexDirection: 'column' }}>
+        var isRecEmpty = this.state.recommendations.length == 0;
+        var divId = isRecEmpty ? "oneViewWidgetContainer" : "widgetContainer";
+        
+        return (<div id={divId} style={{ flexDirection: 'column' }}>
                     <div style={{ display: 'flex', flexDirection: 'row' }}>
                       <CurrentVisComponent intent={this.state.intent} currentVisSpec={this.state.currentVis} numRecommendations={this.state.recommendations.length}
                       onChange={this.handleCurrentVisSelect}/>
-                      <div id="tabBanner">
+                      {!isRecEmpty && <div id="tabBanner">
                         <p className="title-description" style={{visibility: !_.isEmpty(this.state.currentVis) ? 'visible' : 'hidden' }}>You might be interested in...</p>
                         <Tabs activeKey={this.state.activeTab} id="tabBannerList" onSelect={this.handleSelect} className={!_.isEmpty(this.state.currentVis) ? "tabBannerPadding" : ""}>
                           {this.state.tabItems}
                         </Tabs>
-                      </div>
+                      </div>}
                     </div>
                     <ButtonsBroker buttonsEnabled={buttonsEnabled}
                                      deleteSelection={this.deleteSelection}
@@ -364,15 +350,14 @@ export class LuxWidgetView extends DOMWidgetView {
                                      showAlert={this.state.showAlert}
                                      intentEnabled={intentEnabled}
                                      />
-                    <WarningBtn message={this.state.message} toggleWarningPanel={this.toggleWarningPanel} openWarning={this.state.openWarning} />
+                    {!isRecEmpty && <WarningBtn message={this.state.message} toggleWarningPanel={this.toggleWarningPanel} openWarning={this.state.openWarning} />}
                   </div>);
-        }
       }
     }
     const $app = document.createElement("div");
     const App = React.createElement(ReactWidget,view);
     ReactDOM.render(App,$app); // Renders the app
     view.el.append($app); //attaches the rendered app to the DOM (both are required for the widget to show)
-    dispatchLogEvent("initWidget","")
+    dispatchLogEvent("initWidget","");
   }
 }


### PR DESCRIPTION
Overview + Changes
The frontend first loads in the first tab on initialization. Then, it listens for changes on a variable to see when tabs are finished. I also refactored some code for better readability.

Backend PR: https://github.com/lux-org/lux/pull/291


Example Output
![gLSRGNmTpB](https://user-images.githubusercontent.com/47467363/109625967-6af14780-7aec-11eb-97a3-1ea91524d283.gif)
