### PR TITLE
Default value for plottingScale

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -106,7 +106,7 @@ export class LuxWidgetView extends DOMWidgetView {
           currentVisSelected: -2,
           openWarning: false,
           openInfo: false,
-          plottingScale: props.model.get("plotting_scale")
+          plottingScale: props.model.get("plotting_scale") || 1
         }
 
         // This binding is necessary to make `this` work in the callback


### PR DESCRIPTION
When `plottingScale` is not passed currently it results in width and height being scaled to 0 and the main visualization not showing, this was the root of lux-org/lux#242. This PR set a default value for `plottingScale` or `1`.